### PR TITLE
Features/chapter1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,39 @@ A REST API that can be used to create, edit and delete Trivia games with questio
 ## Installation
 
 ```bash
-$ npm install
+$ pnpm install
 ```
 
 ## Running the app
 
 ```bash
 # development
-$ npm run start
+$ pnpm run start
 
 # watch mode
-$ npm run start:dev
+$ pnpm run start:dev
 
 # production mode
-$ npm run start:prod
+$ pnpm run start:prod
 ```
 
 ## Test
 
 ```bash
 # unit tests
-$ npm run test
+$ pnpm run test
+
+# unit tests in watch mode
+$ pnpm run test:watch
+
+# verbose unit tests in watch mode
+$ pnpm run test:verbose
 
 # e2e tests
-$ npm run test:e2e
+$ pnpm run test:e2e
 
 # test coverage
-$ npm run test:cov
+$ pnpm run test:cov
 ```
 
 ## Shout out to 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   "dependencies": {
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^8.0.0",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.13.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "class-validator": "^0.13.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.0.0",
@@ -39,6 +40,7 @@
     "@types/jest": "^27.0.1",
     "@types/node": "^16.0.0",
     "@types/supertest": "^2.0.11",
+    "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
     "eslint": "^7.30.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
-    "test:watch": "jest --watch",
+    "test:verbose": "jest --watch --verbose --maxWorkers=1",
+    "test:watch": "jest --watch --maxWorkers=1",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@nestjs/cli': ^8.0.0
   '@nestjs/common': ^8.0.0
   '@nestjs/core': ^8.0.0
+  '@nestjs/mapped-types': '*'
   '@nestjs/platform-express': ^8.0.0
   '@nestjs/schematics': ^8.0.0
   '@nestjs/testing': ^8.0.0
@@ -13,6 +14,8 @@ specifiers:
   '@types/supertest': ^2.0.11
   '@typescript-eslint/eslint-plugin': ^4.28.2
   '@typescript-eslint/parser': ^4.28.2
+  class-transformer: ^0.4.0
+  class-validator: ^0.13.1
   eslint: ^7.30.0
   eslint-config-prettier: ^8.3.0
   eslint-plugin-prettier: ^3.4.0
@@ -29,9 +32,12 @@ specifiers:
   typescript: ^4.3.5
 
 dependencies:
-  '@nestjs/common': 8.1.1_ad16f1f28877c5242670873e13562245
+  '@nestjs/common': 8.1.1_43f93dd897e68fe834a23ddd32fb54cc
   '@nestjs/core': 8.1.1_fd2a30749d40d79b96b1254a3e96f533
+  '@nestjs/mapped-types': 1.0.0_69880b072bf1a4e177f038f9fbb7a28e
   '@nestjs/platform-express': 8.1.1_9569caea4829e1e6a54e03a46e955ce7
+  class-transformer: 0.4.0
+  class-validator: 0.13.1
   reflect-metadata: 0.1.13
   rimraf: 3.0.2
   rxjs: 7.4.0
@@ -728,7 +734,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nestjs/common/8.1.1_ad16f1f28877c5242670873e13562245:
+  /@nestjs/common/8.1.1_43f93dd897e68fe834a23ddd32fb54cc:
     resolution: {integrity: sha512-4do6SZrvBV4jz3Gf+uLz91kwkhXRxdAqe+jGLqNd4xMaArmT9L4xHngXdnv7wKOFCKb7Bc9EP4KfqS4z451npg==}
     peerDependencies:
       cache-manager: '*'
@@ -745,6 +751,8 @@ packages:
         optional: true
     dependencies:
       axios: 0.23.0
+      class-transformer: 0.4.0
+      class-validator: 0.13.1
       iterare: 1.2.1
       reflect-metadata: 0.1.13
       rxjs: 7.4.0
@@ -772,7 +780,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 8.1.1_ad16f1f28877c5242670873e13562245
+      '@nestjs/common': 8.1.1_43f93dd897e68fe834a23ddd32fb54cc
       '@nestjs/platform-express': 8.1.1_9569caea4829e1e6a54e03a46e955ce7
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
@@ -785,13 +793,27 @@ packages:
       uuid: 8.3.2
     dev: false
 
+  /@nestjs/mapped-types/1.0.0_69880b072bf1a4e177f038f9fbb7a28e:
+    resolution: {integrity: sha512-26AW5jHadLXtvHs+M+Agd9KZ92dDlBrmD0rORlBlvn2KvsWs4JRaKl2mUsrW7YsdZeAu3Hc4ukqyYyDdyCmMWQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.8 || ^8.0.0
+      class-transformer: ^0.2.0 || ^0.3.0 || ^0.4.0
+      class-validator: ^0.11.1 || ^0.12.0 || ^0.13.0
+      reflect-metadata: ^0.1.12
+    dependencies:
+      '@nestjs/common': 8.1.1_43f93dd897e68fe834a23ddd32fb54cc
+      class-transformer: 0.4.0
+      class-validator: 0.13.1
+      reflect-metadata: 0.1.13
+    dev: false
+
   /@nestjs/platform-express/8.1.1_9569caea4829e1e6a54e03a46e955ce7:
     resolution: {integrity: sha512-AIZIYjlctGKdWW1f1TDMJSJiDjUtR06b40nwUkfk22d/ZR0XM4OFtxMjrKC+HyR14ctaKUVU4pmzqFcQxymwXQ==}
     peerDependencies:
       '@nestjs/common': ^8.0.0
       '@nestjs/core': ^8.0.0
     dependencies:
-      '@nestjs/common': 8.1.1_ad16f1f28877c5242670873e13562245
+      '@nestjs/common': 8.1.1_43f93dd897e68fe834a23ddd32fb54cc
       '@nestjs/core': 8.1.1_fd2a30749d40d79b96b1254a3e96f533
       body-parser: 1.19.0
       cors: 2.8.5
@@ -840,7 +862,7 @@ packages:
         optional: true
     dependencies:
       optional: 0.1.4
-      '@nestjs/common': 8.1.1_ad16f1f28877c5242670873e13562245
+      '@nestjs/common': 8.1.1_43f93dd897e68fe834a23ddd32fb54cc
       '@nestjs/core': 8.1.1_fd2a30749d40d79b96b1254a3e96f533
       '@nestjs/platform-express': 8.1.1_9569caea4829e1e6a54e03a46e955ce7
       tslib: 2.3.1
@@ -1075,6 +1097,10 @@ packages:
     dependencies:
       '@types/superagent': 4.1.13
     dev: true
+
+  /@types/validator/13.6.5:
+    resolution: {integrity: sha512-ilpDKpjjq/w/IyyTuQ38mABdaEzTzTugPyU7DlMCMKd8MMYngnPKhA2TgdO1MfEDED9KVV7uSOL1fDkgwJp/wg==}
+    dev: false
 
   /@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
@@ -1764,6 +1790,18 @@ packages:
   /cjs-module-lexer/1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
     dev: true
+
+  /class-transformer/0.4.0:
+    resolution: {integrity: sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==}
+    dev: false
+
+  /class-validator/0.13.1:
+    resolution: {integrity: sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==}
+    dependencies:
+      '@types/validator': 13.6.5
+      libphonenumber-js: 1.9.39
+      validator: 13.6.0
+    dev: false
 
   /cli-cursor/3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -3636,6 +3674,10 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /libphonenumber-js/1.9.39:
+    resolution: {integrity: sha512-TxYz/Ii7mjkocKGKmFHhsTAvvcxr4AY3yUlZzZ2z7HC4DPRrNlzJ9n32/SMogqsyFOXLMXQPCkCInNRbiVaEPA==}
+    dev: false
+
   /lines-and-columns/1.1.6:
     resolution: {integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=}
     dev: true
@@ -4995,6 +5037,11 @@ packages:
       convert-source-map: 1.8.0
       source-map: 0.7.3
     dev: true
+
+  /validator/13.6.0:
+    resolution: {integrity: sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /vary/1.1.2:
     resolution: {integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ specifiers:
   '@types/jest': ^27.0.1
   '@types/node': ^16.0.0
   '@types/supertest': ^2.0.11
+  '@types/uuid': ^8.3.1
   '@typescript-eslint/eslint-plugin': ^4.28.2
   '@typescript-eslint/parser': ^4.28.2
   class-transformer: ^0.4.0
@@ -30,6 +31,7 @@ specifiers:
   ts-node: ^10.0.0
   tsconfig-paths: ^3.10.1
   typescript: ^4.3.5
+  uuid: ^8.3.2
 
 dependencies:
   '@nestjs/common': 8.1.1_43f93dd897e68fe834a23ddd32fb54cc
@@ -41,6 +43,7 @@ dependencies:
   reflect-metadata: 0.1.13
   rimraf: 3.0.2
   rxjs: 7.4.0
+  uuid: 8.3.2
 
 devDependencies:
   '@nestjs/cli': 8.1.4_eslint@7.32.0
@@ -50,6 +53,7 @@ devDependencies:
   '@types/jest': 27.0.2
   '@types/node': 16.11.1
   '@types/supertest': 2.0.11
+  '@types/uuid': 8.3.1
   '@typescript-eslint/eslint-plugin': 4.33.0_cc617358c89d3f38c52462f6d809db4c
   '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
   eslint: 7.32.0
@@ -1096,6 +1100,10 @@ packages:
     resolution: {integrity: sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==}
     dependencies:
       '@types/superagent': 4.1.13
+    dev: true
+
+  /@types/uuid/8.3.1:
+    resolution: {integrity: sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==}
     dev: true
 
   /@types/validator/13.6.5:

--- a/quizzes.json
+++ b/quizzes.json
@@ -1,0 +1,60 @@
+{
+  "1ea8dcd0-e6a0-4d59-96da-40c9a3aa216c": {
+    "id": "1ea8dcd0-e6a0-4d59-96da-40c9a3aa216c",
+    "name": "Wizards and witches",
+    "questions": [
+      {
+        "id": "17c8e762-057b-4cc6-b0e8-e95b1a966060",
+        "statement": "Which house was the sorting hat going to send Harry Potter to?",
+        "answers": [
+          {
+            "id": "08ab3007-e673-49c1-91a9-b5720042287b",
+            "statement": "Gryffindor",
+            "isCorrect": false
+          },
+          {
+            "id": "59b49410-3244-4096-825b-fc96ce7a0aa4",
+            "statement": "Hufflepuff",
+            "isCorrect": false
+          },
+          {
+            "id": "5b7be038-5a28-42ad-807b-3ef3f7100aac",
+            "statement": "Ravenclaw",
+            "isCorrect": false
+          },
+          {
+            "id": "09090e36-4b77-44c3-a6d1-e8c1a3fee45a",
+            "statement": "Slytherin",
+            "isCorrect": true
+          }
+        ]
+      },
+      {
+        "id": "b7f70c84-5262-475b-ab27-9f00e634af1d",
+        "statement": "Which house did the sorting hat end up sending Harry Potter to?",
+        "answers": [
+          {
+            "id": "fb5ead1c-5de7-40e9-ae93-613cc6d92130",
+            "statement": "Gryffindor",
+            "isCorrect": true
+          },
+          {
+            "id": "bddf3d08-4f11-46b6-b84d-27cd3cf7ac7c",
+            "statement": "Hufflepuff",
+            "isCorrect": false
+          },
+          {
+            "id": "cd2f4a74-5de8-423c-987b-21c68a867598",
+            "statement": "Ravenclaw",
+            "isCorrect": false
+          },
+          {
+            "id": "9fbee016-9b2f-4776-9589-5af108fa4e50",
+            "statement": "Slytherin",
+            "isCorrect": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { QuizzesModule } from './quizzes/quizzes.module';
 
 @Module({
-  imports: [],
+  imports: [QuizzesModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);
 }
 bootstrap();

--- a/src/quizzes/answers.controller.spec.ts
+++ b/src/quizzes/answers.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnswersController } from './answers.controller';
+import { AnswersService } from './answers.service';
+
+describe('AnswersController', () => {
+  let controller: AnswersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnswersController],
+      providers: [AnswersService],
+    }).compile();
+
+    controller = module.get<AnswersController>(AnswersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/quizzes/answers.controller.ts
+++ b/src/quizzes/answers.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { AnswersService } from './answers.service';
+import { CreateAnswerDto } from './dto/create-answer.dto';
+import { UpdateAnswerDto } from './dto/update-answer.dto';
+
+@Controller('answers')
+export class AnswersController {
+  constructor(private readonly answersService: AnswersService) {}
+
+  @Post()
+  create(@Body() createAnswerDto: CreateAnswerDto) {
+    return this.answersService.create(createAnswerDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.answersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.answersService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateAnswerDto: UpdateAnswerDto) {
+    return this.answersService.update(+id, updateAnswerDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.answersService.remove(+id);
+  }
+}

--- a/src/quizzes/answers.module.ts
+++ b/src/quizzes/answers.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AnswersService } from './answers.service';
+import { AnswersController } from './answers.controller';
+
+@Module({
+  controllers: [AnswersController],
+  providers: [AnswersService]
+})
+export class AnswersModule {}

--- a/src/quizzes/answers.repository.ts
+++ b/src/quizzes/answers.repository.ts
@@ -1,0 +1,75 @@
+import { UpdateAnswerDto } from './dto/update-answer.dto';
+import { CreateAnswerDto } from './dto/create-answer.dto';
+import { readFile, writeFile } from 'fs/promises';
+import { randomUUID } from 'crypto';
+import { Answer } from './entities/answer.entity';
+import {
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+/*
+  This class will be decorated with @EntityRepository(Answer)
+  and made it extend Repository<Answer> when refactoring for ORM
+  For now I'll just make it @Injectable
+  All operations shall cascade through ORM as well, but we'll add
+  all this code manually.
+*/
+@Injectable()
+export class AnswersRepository {
+  async create(createAnswerDto: CreateAnswerDto): Promise<Answer> {
+      /* 
+        Might be a bit excessive here, but I'm planning on 
+        using uuid when introducing ORM, so I'll start generating 
+        the id manually here. This message shall be erased with 
+        that refactor anyways
+      */
+      const id = randomUUID();
+
+      let answer = {
+        id,
+        ...createAnswerDto,
+      };
+
+      return Promise.resolve(answer as Answer);
+  }
+
+  async findAll(): Promise<Answer[]> {
+    
+    try {
+      const file = await readFile('Answers.json', 'utf8');
+      const Answers = JSON.parse(file);
+
+      return Promise.resolve(Answers as Answer[]);
+    } catch (err) {
+      throw new NotFoundException(err.errno);
+    }
+  }
+
+  async findOne(id: string): Promise<Answer> {
+    let Answer: Answer;
+    try {
+      const file = await readFile('Answers.json', 'utf8');
+      const Answers = JSON.parse(file);
+      Answer = Answers[id] as Answer;
+    } catch (err) {
+      throw new NotFoundException(err.errno);
+    }
+
+    if (!Answer) {
+      throw new NotFoundException(
+        `No Answer with id ${id} exists in the collection.`,
+      );
+    }
+
+    return Promise.resolve(Answer);
+  }
+
+  async update(id: string, updateAnswerDto: UpdateAnswerDto) {
+    return `This action updates a #${id} Answer`;
+  }
+
+  async remove(id: string) {
+    return `This action removes a #${id} Answer`;
+  }
+}

--- a/src/quizzes/answers.service.spec.ts
+++ b/src/quizzes/answers.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnswersService } from './answers.service';
+
+describe('AnswersService', () => {
+  let service: AnswersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AnswersService],
+    }).compile();
+
+    service = module.get<AnswersService>(AnswersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/quizzes/answers.service.ts
+++ b/src/quizzes/answers.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateAnswerDto } from './dto/create-answer.dto';
+import { UpdateAnswerDto } from './dto/update-answer.dto';
+
+@Injectable()
+export class AnswersService {
+  create(createAnswerDto: CreateAnswerDto) {
+    return 'This action adds a new answer';
+  }
+
+  findAll() {
+    return `This action returns all answers`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} answer`;
+  }
+
+  update(id: number, updateAnswerDto: UpdateAnswerDto) {
+    return `This action updates a #${id} answer`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} answer`;
+  }
+}

--- a/src/quizzes/dto/create-answer.dto.ts
+++ b/src/quizzes/dto/create-answer.dto.ts
@@ -1,0 +1,9 @@
+import { IsBoolean, IsString } from "class-validator";
+
+export class CreateAnswerDto {
+  @IsString()
+  readonly statement: string;
+
+  @IsBoolean()
+  readonly isCorrect: boolean;
+}

--- a/src/quizzes/dto/create-question.dto.ts
+++ b/src/quizzes/dto/create-question.dto.ts
@@ -1,0 +1,13 @@
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsString, ValidateNested } from 'class-validator';
+import { Answer } from './../entities/answer.entity';
+
+export class CreateQuestionDto {
+  @IsString()
+  readonly statement: string;
+  
+  @IsArray()
+  @ArrayMinSize(4)
+  @ArrayMaxSize(4)
+  @ValidateNested()
+  readonly answers: Answer[];
+}

--- a/src/quizzes/dto/create-quiz.dto.ts
+++ b/src/quizzes/dto/create-quiz.dto.ts
@@ -1,0 +1,12 @@
+import { IsArray, IsString, ValidateNested } from 'class-validator';
+import { Question } from './../entities/question.entity';
+
+export class CreateQuizDto {
+
+  @IsString()
+  readonly name: string;
+
+  @IsArray()
+  @ValidateNested()
+  readonly questions: Question[];
+}

--- a/src/quizzes/dto/update-answer.dto.ts
+++ b/src/quizzes/dto/update-answer.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAnswerDto } from './create-answer.dto';
+
+export class UpdateAnswerDto extends PartialType(CreateAnswerDto) {}

--- a/src/quizzes/dto/update-question.dto.ts
+++ b/src/quizzes/dto/update-question.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateQuestionDto } from './create-question.dto';
+
+export class UpdateQuestionDto extends PartialType(CreateQuestionDto) {}

--- a/src/quizzes/dto/update-quiz.dto.ts
+++ b/src/quizzes/dto/update-quiz.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateQuizDto } from './create-quiz.dto';
+
+export class UpdateQuizDto extends PartialType(CreateQuizDto) {}

--- a/src/quizzes/entities/answer.entity.ts
+++ b/src/quizzes/entities/answer.entity.ts
@@ -1,0 +1,5 @@
+export class Answer {
+  id: string;
+  statement: string;
+  isCorrect: boolean;
+}

--- a/src/quizzes/entities/question.entity.ts
+++ b/src/quizzes/entities/question.entity.ts
@@ -1,0 +1,7 @@
+import { Answer } from './answer.entity';
+
+export class Question {
+  id: string;
+  statement: string;
+  answers: Answer[];
+}

--- a/src/quizzes/entities/quiz.entity.ts
+++ b/src/quizzes/entities/quiz.entity.ts
@@ -1,0 +1,7 @@
+import { Question } from './question.entity';
+
+export class Quiz {
+  id: string;
+  name: string;
+  questions: Question[];
+}

--- a/src/quizzes/questions.controller.spec.ts
+++ b/src/quizzes/questions.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuestionsController } from './questions.controller';
+import { QuestionsService } from './questions.service';
+
+describe('QuestionsController', () => {
+  let controller: QuestionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuestionsController],
+      providers: [QuestionsService],
+    }).compile();
+
+    controller = module.get<QuestionsController>(QuestionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/quizzes/questions.controller.ts
+++ b/src/quizzes/questions.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { QuestionsService } from './questions.service';
+import { CreateQuestionDto } from './dto/create-question.dto';
+import { UpdateQuestionDto } from './dto/update-question.dto';
+
+@Controller('questions')
+export class QuestionsController {
+  constructor(private readonly questionsService: QuestionsService) {}
+
+  @Post()
+  create(@Body() createQuestionDto: CreateQuestionDto) {
+    return this.questionsService.create(createQuestionDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.questionsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.questionsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateQuestionDto: UpdateQuestionDto) {
+    return this.questionsService.update(+id, updateQuestionDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.questionsService.remove(+id);
+  }
+}

--- a/src/quizzes/questions.module.ts
+++ b/src/quizzes/questions.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { QuestionsService } from './questions.service';
+import { QuestionsController } from './questions.controller';
+import { AnswersModule } from './answers.module';
+
+@Module({
+  controllers: [QuestionsController],
+  providers: [QuestionsService],
+  imports: [AnswersModule]
+})
+export class QuestionsModule {}

--- a/src/quizzes/questions.repository.ts
+++ b/src/quizzes/questions.repository.ts
@@ -1,0 +1,73 @@
+import { UpdateQuestionDto } from './dto/update-question.dto';
+import { CreateQuestionDto } from './dto/create-question.dto';
+import { readFile, writeFile } from 'fs/promises';
+import { randomUUID } from 'crypto';
+import { Question } from './entities/question.entity';
+import {
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+/*
+  This class will be decorated with @EntityRepository(Question)
+  and made it extend Repository<Question> when refactoring for ORM
+  For now I'll just make it @Injectable
+  All operations shall cascade through ORM as well, but we'll add
+  all this code manually.
+*/
+@Injectable()
+export class QuestionsRepository {
+  async create(createQuestionDto: CreateQuestionDto): Promise<Question> {
+      /* 
+        I'm planning on using uuid when introducing ORM
+        so I'll start generating the id manually here. This
+        message shall be erased with that refactor anyways
+      */
+      const id = randomUUID();
+
+      let question = {
+        id,
+        ...createQuestionDto,
+      };
+
+      return Promise.resolve(question as Question);
+  }
+
+  async findAll(): Promise<Question[]> {
+    try {
+      const file = await readFile('questions.json', 'utf8');
+      const questions = JSON.parse(file);
+
+      return Promise.resolve(questions as Question[]);
+    } catch (err) {
+      throw new NotFoundException(err.errno);
+    }
+  }
+
+  async findOne(id: string): Promise<Question> {
+    let question: Question;
+    try {
+      const file = await readFile('questions.json', 'utf8');
+      const questions = JSON.parse(file);
+      question = questions[id] as Question;
+    } catch (err) {
+      throw new NotFoundException(err.errno);
+    }
+
+    if (!question) {
+      throw new NotFoundException(
+        `No question with id ${id} exists in the collection.`,
+      );
+    }
+
+    return Promise.resolve(question);
+  }
+
+  async update(id: string, updateQuestionDto: UpdateQuestionDto) {
+    return `This action updates a #${id} question`;
+  }
+
+  async remove(id: string) {
+    return `This action removes a #${id} question`;
+  }
+}

--- a/src/quizzes/questions.service.spec.ts
+++ b/src/quizzes/questions.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuestionsService } from './questions.service';
+
+describe('QuestionsService', () => {
+  let service: QuestionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuestionsService],
+    }).compile();
+
+    service = module.get<QuestionsService>(QuestionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/quizzes/questions.service.ts
+++ b/src/quizzes/questions.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateQuestionDto } from './dto/create-question.dto';
+import { UpdateQuestionDto } from './dto/update-question.dto';
+
+@Injectable()
+export class QuestionsService {
+  create(createQuestionDto: CreateQuestionDto) {
+    return 'This action adds a new question';
+  }
+
+  findAll() {
+    return `This action returns all questions`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} question`;
+  }
+
+  update(id: number, updateQuestionDto: UpdateQuestionDto) {
+    return `This action updates a #${id} question`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} question`;
+  }
+}

--- a/src/quizzes/quizzes.controller.spec.ts
+++ b/src/quizzes/quizzes.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizzesController } from './quizzes.controller';
+import { QuizzesService } from './quizzes.service';
+
+describe('QuizzesController', () => {
+  let controller: QuizzesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuizzesController],
+      providers: [QuizzesService],
+    }).compile();
+
+    controller = module.get<QuizzesController>(QuizzesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/quizzes/quizzes.controller.spec.ts
+++ b/src/quizzes/quizzes.controller.spec.ts
@@ -1,3 +1,4 @@
+import { QuizzesRepository } from './quizzes.repository';
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuizzesController } from './quizzes.controller';
 import { QuizzesService } from './quizzes.service';
@@ -8,7 +9,7 @@ describe('QuizzesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [QuizzesController],
-      providers: [QuizzesService],
+      providers: [QuizzesService, QuizzesRepository],
     }).compile();
 
     controller = module.get<QuizzesController>(QuizzesController);

--- a/src/quizzes/quizzes.controller.ts
+++ b/src/quizzes/quizzes.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { QuizzesService } from './quizzes.service';
+import { CreateQuizDto } from './dto/create-quiz.dto';
+import { UpdateQuizDto } from './dto/update-quiz.dto';
+
+@Controller('quizzes')
+export class QuizzesController {
+  constructor(private readonly quizzesService: QuizzesService) {}
+
+  @Post()
+  create(@Body() createQuizDto: CreateQuizDto) {
+    return this.quizzesService.create(createQuizDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.quizzesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.quizzesService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateQuizDto: UpdateQuizDto) {
+    return this.quizzesService.update(+id, updateQuizDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.quizzesService.remove(+id);
+  }
+}

--- a/src/quizzes/quizzes.controller.ts
+++ b/src/quizzes/quizzes.controller.ts
@@ -19,16 +19,16 @@ export class QuizzesController {
 
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.quizzesService.findOne(+id);
+    return this.quizzesService.findOne(id);
   }
 
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateQuizDto: UpdateQuizDto) {
-    return this.quizzesService.update(+id, updateQuizDto);
+    return this.quizzesService.update(id, updateQuizDto);
   }
 
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return this.quizzesService.remove(+id);
+    return this.quizzesService.remove(id);
   }
 }

--- a/src/quizzes/quizzes.module.ts
+++ b/src/quizzes/quizzes.module.ts
@@ -1,3 +1,5 @@
+import { QuestionsRepository } from './questions.repository';
+import { QuizzesRepository } from './quizzes.repository';
 import { Module } from '@nestjs/common';
 import { QuizzesService } from './quizzes.service';
 import { QuizzesController } from './quizzes.controller';
@@ -5,7 +7,7 @@ import { QuestionsModule } from './questions.module';
 
 @Module({
   controllers: [QuizzesController],
-  providers: [QuizzesService],
+  providers: [QuizzesService, QuizzesRepository, QuestionsRepository],
   imports: [QuestionsModule]
 })
 export class QuizzesModule {}

--- a/src/quizzes/quizzes.module.ts
+++ b/src/quizzes/quizzes.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { QuizzesService } from './quizzes.service';
+import { QuizzesController } from './quizzes.controller';
+import { QuestionsModule } from './questions.module';
+
+@Module({
+  controllers: [QuizzesController],
+  providers: [QuizzesService],
+  imports: [QuestionsModule]
+})
+export class QuizzesModule {}

--- a/src/quizzes/quizzes.repository.ts
+++ b/src/quizzes/quizzes.repository.ts
@@ -48,7 +48,7 @@ export class QuizzesRepository {
     const questions = providedQuizDto.questions;
     if (!questions || questions.length < 1) {
       throw new BadRequestException(
-        `The provided Quiz ${providedQuizDto.name} should contain at least one question.`,
+        `The provided Quiz “${providedQuizDto.name}” should contain at least one question.`,
       );
     }
     // Now, make sure each question contains exactly 4 valid answers
@@ -67,7 +67,7 @@ export class QuizzesRepository {
         .reduce((previous, current) => previous + current);
       if (thereCanBeOnlyOne !== 1) {
         throw new BadRequestException(
-          `The provided Quiz's question: “${question.statement}” must contain 1 and only 1 true answer.`,
+          `The provided Quiz's question “${question.statement}” must contain 1 and only 1 true answer.`,
         );
       }
       // My eyes! My eeeyes!! But the ORM refactor will fix this too
@@ -105,7 +105,7 @@ export class QuizzesRepository {
 
     if (!quiz) {
       throw new NotFoundException(
-        `No quiz with id ${id} exists in the collection.`,
+        `No quiz with id “${id}” exists in the collection.`,
       );
     }
 
@@ -136,7 +136,7 @@ export class QuizzesRepository {
       let msg:string;
       switch(err.response.statusCode) {
         case HttpStatus.NOT_FOUND:
-          msg = `Quiz id ${id} doesn't match any existing record. Please verify the provided update data.`;
+          msg = `Quiz id “${id}” doesn't match any existing record. Please verify the provided update data.`;
           break;
         default:
           msg = err.response.message;
@@ -155,7 +155,7 @@ export class QuizzesRepository {
       return;
     } catch (err) {
       throw new BadRequestException(
-        `Can't delete a record which doesn't exist. Please verify and fix the id ${id}.`,
+        `Can't delete a record which doesn't exist. Please verify and fix the id “${id}”.`,
       );
     }
   }

--- a/src/quizzes/quizzes.repository.ts
+++ b/src/quizzes/quizzes.repository.ts
@@ -1,0 +1,162 @@
+import {
+  BadRequestException,
+  HttpStatus,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { CreateQuizDto } from './dto/create-quiz.dto';
+import { UpdateQuizDto } from './dto/update-quiz.dto';
+import { randomUUID } from 'crypto';
+import { Quiz } from './entities/quiz.entity';
+import { Question } from './entities/question.entity';
+import { Answer } from './entities/answer.entity';
+import { readFileSync } from 'fs';
+
+/*
+  I have two options here:
+  1. Handle all entities and validations right here (quick & dirty)
+  2. Handle each one in its right place (separate classes, a lot of
+    coding that will be refactored with Chapter 2 anyway)
+  Since the assignment speaks only of API calls to quizzes (and not 
+    questions or answers on their own), and I know I'll refactor it
+    shortly, I'll go the quick & dirty route for now, so as to minimize 
+    the amount of changes implied.
+  This class will be decorated with @EntityRepository(Quiz)
+  and made it extend Repository<Quiz> when refactoring for ORM
+  For now I'll just make it @Injectable
+*/
+@Injectable()
+export class QuizzesRepository {
+  private quizzes: Quiz[];
+
+  constructor() {
+    // Just to provide it with some data, let's load some quiz into the on-memory array
+    // This will be refactored too when ORM comes to town
+    try {
+      const file = readFileSync('quizzes.json', 'utf8');
+      this.quizzes = JSON.parse(file) as Quiz[];
+    } catch (err) {
+      // Just output it in the console.log, it won't hurt the ability of the endpoints to work
+      console.log(err);
+    }
+  }
+
+  // This hurts my eyes, but... for now, let's just place a big bulky
+  //  all-in validation function for both create and update methods
+  validateInput(providedQuizDto: CreateQuizDto | UpdateQuizDto): Quiz {
+    // Make sure there's at least one question in that Dto
+    const questions = providedQuizDto.questions;
+    if (!questions || questions.length < 1) {
+      throw new BadRequestException(
+        `The provided Quiz ${providedQuizDto.name} should contain at least one question.`,
+      );
+    }
+    // Now, make sure each question contains exactly 4 valid answers
+    // This control will be refactored into its own QuestionsRepository class
+    for (let question of questions) {
+      let answers = question.answers;
+      if (!answers || answers.length !== 4) {
+        throw new BadRequestException(
+          `The provided Quiz's question “${question.statement}” should contain exactly 4 answers.`,
+        );
+      }
+      // The + in +answer.isCorrect is that nice casting trick from boolean to number (true->1, false ->0)
+      //  so, the reduce running sum should be 1 (only one correct answer, i.e. one true value)
+      let thereCanBeOnlyOne = answers
+        .map((answer) => +answer.isCorrect)
+        .reduce((previous, current) => previous + current);
+      if (thereCanBeOnlyOne !== 1) {
+        throw new BadRequestException(
+          `The provided Quiz's question: “${question.statement}” must contain 1 and only 1 true answer.`,
+        );
+      }
+      // My eyes! My eeeyes!! But the ORM refactor will fix this too
+      for (let answer of answers) {
+        answer.id = randomUUID(); // Let's give each answer an id
+      }
+
+      question.id = randomUUID(); // Let's give this question an id too...
+      question.answers = answers; // ... and update its answers set, now with ids
+    }
+
+    // And now update the quiz's question with their ids, and an id of its own
+    const validQuiz = {
+      id: randomUUID(),
+      ...providedQuizDto,
+      questions,
+    } as Quiz;
+
+    return validQuiz;
+  }
+
+  async create(createQuizDto: CreateQuizDto): Promise<Quiz> {
+    let newQuiz = this.validateInput(createQuizDto);
+    // Don't forget to add it to the on-memory collection, and return it... as promised
+    this.quizzes[newQuiz.id] = newQuiz;
+    return Promise.resolve(newQuiz);
+  }
+
+  async findAll(): Promise<Quiz[]> {
+    return Promise.resolve(this.quizzes as Quiz[]);
+  }
+
+  async findOne(id: string): Promise<Quiz> {
+    let quiz = this.quizzes[id] as Quiz;
+
+    if (!quiz) {
+      throw new NotFoundException(
+        `No quiz with id ${id} exists in the collection.`,
+      );
+    }
+
+    return Promise.resolve(quiz);
+  }
+
+  async update(id: string, updateQuizDto: UpdateQuizDto) {
+    // By wrapping the this.findOne call in a try catch we can throw a 400 Bad Request
+    //  instead of the 404 Not Found triggered by the findOne function itself, or other
+    //  messages if it's any validation step that fails instead
+    try {
+      let oldQuiz = await this.findOne(id);
+      // It's a patch, not a put, so we accept a simple { "name": "Example quiz" } as request body.
+      // Still, for the validation function to work, we need to pass the entire Quiz, not just its
+      //  patched properties and values. If the patch doesn't contain a modified set of questions,
+      //  it will keep its previous one.
+      // But if it contains a modified set of questions, it shall replace the previous one at face 
+      //  value (i.e., if a previous question is missing, we assume the user wants to delete it,
+      //  not leave it as it was before the patch request, and the same goes for their answers). 
+      let updatedQuiz = this.validateInput({
+        ...oldQuiz,
+        ...updateQuizDto
+      } as UpdateQuizDto);
+      // Update the in-memory collection
+      this.quizzes[updatedQuiz.id] = updatedQuiz;
+      return Promise.resolve(updatedQuiz);
+    } catch (err) {
+      let msg:string;
+      switch(err.response.statusCode) {
+        case HttpStatus.NOT_FOUND:
+          msg = `Quiz id ${id} doesn't match any existing record. Please verify the provided update data.`;
+          break;
+        default:
+          msg = err.response.message;
+      }
+      throw new BadRequestException(msg);
+    }
+  }
+
+  async remove(id: string) {
+    // By wrapping the this.findOne call in a try catch we can throw the proper 400 Bad Request
+    //  instead of the 404 Not Found triggered by the findOne function itself
+    try {
+      let oldQuiz = await this.findOne(id);
+      // Remove quiz from the in-memory collection
+      delete this.quizzes[oldQuiz.id];
+      return;
+    } catch (err) {
+      throw new BadRequestException(
+        `Can't delete a record which doesn't exist. Please verify and fix the id ${id}.`,
+      );
+    }
+  }
+}

--- a/src/quizzes/quizzes.service.spec.ts
+++ b/src/quizzes/quizzes.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizzesService } from './quizzes.service';
+
+describe('QuizzesService', () => {
+  let service: QuizzesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuizzesService],
+    }).compile();
+
+    service = module.get<QuizzesService>(QuizzesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/quizzes/quizzes.service.spec.ts
+++ b/src/quizzes/quizzes.service.spec.ts
@@ -1,18 +1,302 @@
+import { QuestionsRepository } from './questions.repository';
+import { UpdateQuizDto } from './dto/update-quiz.dto';
+import { CreateQuizDto } from './dto/create-quiz.dto';
+import { BadRequestException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { Quiz } from './entities/quiz.entity';
+import { QuizzesRepository } from './quizzes.repository';
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuizzesService } from './quizzes.service';
 
+/*
+  NOTE: Since we're not using ORM yet, and the repository is only faking async responses,
+        the repository here is the real deal, not a mock one. The purpose is to actually
+        test whether the repository refactor actually works. Should any of these tests 
+        fail, we'll know where some work still needs to be done.
+        And once the refactor is complete and working, we will probably want to modify
+        these tests replaciong the actual QuizzesRepository with a mock one.
+*/
+
+// const mockQuizzesRepositoryFactory = () => ({});
+
 describe('QuizzesService', () => {
+  const quizDto = {
+    name: 'Ultimate life quiz',
+    questions: [
+      {
+        statement: 'How many roads must a man walk down?',
+        answers: [
+          {
+            statement: 'Does a road really need to be walked down?',
+            isCorrect: false,
+          },
+          {
+            statement: 'None',
+            isCorrect: false,
+          },
+          {
+            statement: '42',
+            isCorrect: true,
+          },
+          {
+            statement: '69.000.000',
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  } as CreateQuizDto;
+
+  let badDto: Object;
+  let quiz: Quiz;
+  // let repository: QuizzesRepository;
   let service: QuizzesService;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [QuizzesService],
+      providers: [QuizzesService, QuizzesRepository],
     }).compile();
 
     service = module.get<QuizzesService>(QuizzesService);
+    // repository = module.get<QuizzesRepository>(QuizzesRepository);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  describe('create', () => {
+    describe('a valid quiz', () => {
+      it('should return the new quiz', async () => {
+        quiz = await service.create(quizDto);
+        expect(quiz.name).toEqual(quizDto.name);
+      });
+    });
+    /* 
+      A BadRequestException for a quiz with no name should not be tested here, but in the controller,
+      because of the validation pipe and entities decorators, hence, validating this in the repository
+      is not implemented, so a create request thrown from here would fly even without a name.
+    */
+    describe('a quiz with no questions', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          badDto = {name:quizDto.name};
+          await service.create(badDto as CreateQuizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`The provided Quiz “${quizDto.name}” should contain at least one question.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+    describe('a quiz with no answers', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          badDto = {name:quizDto.name, questions: [{statement:quizDto.questions[0].statement}]};
+          await service.create(badDto as CreateQuizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`The provided Quiz's question “${quizDto.questions[0].statement}” should contain exactly 4 answers.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+    describe('a quiz with more than one true answer', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          badDto = {
+            name:quizDto.name, 
+            questions: [{
+              statement:quizDto.questions[0].statement, 
+              answers: [{...quizDto.questions[0].answers[0],isCorrect:true}, quizDto.questions[0].answers[1], quizDto.questions[0].answers[2], quizDto.questions[0].answers[3]]
+            }]
+          };
+          await service.create(badDto as CreateQuizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`The provided Quiz's question “${quizDto.questions[0].statement}” must contain 1 and only 1 true answer.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+    describe('a quiz with no true answer', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          badDto = {
+            name:quizDto.name, 
+            questions: [{
+              statement:quizDto.questions[0].statement, 
+              answers: [quizDto.questions[0].answers[0], quizDto.questions[0].answers[1], {...quizDto.questions[0].answers[2],isCorrect:false}, quizDto.questions[0].answers[3]]
+            }]
+          };
+          await service.create(badDto as CreateQuizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`The provided Quiz's question “${quizDto.questions[0].statement}” must contain 1 and only 1 true answer.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all quizzes', async () => {
+      const result = await service.findAll();
+      expect(result[quiz.id].name).toEqual(quizDto.name);
+    });
+  });
+
+  describe(`findOne`, () => {
+    describe(`when quiz with provided id exists`, () => {
+      it(`should return the quiz object`, async () => {
+        const foundQuiz = await service.findOne(quiz.id);
+        expect(foundQuiz).toEqual(quiz);
+      });
+    });
+    describe(`when quiz with provided id doesn't exist`, () => {
+      it(`should throw a "NotFoundException"`, async () => {
+        try {
+          await service.findOne(`NOT${quiz.id}`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(NotFoundException);
+          expect(err.message).toEqual(`No quiz with id “NOT${quiz.id}” exists in the collection.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.NOT_FOUND);
+        }
+      });
+    });
+  });
+
+  describe('update', () => {
+    describe('with a name patch', () => {
+      it('should return the updated quiz', async () => {
+        const updatedName = `Ultimate quiz of life`;
+        quiz = await service.update(quiz.id, {name: updatedName} as UpdateQuizDto);
+        expect(quiz.name).toEqual(updatedName);
+      });
+    });
+    describe('with a questions patch', () => {
+      it('should return the updated quiz', async () => {
+        const updatedQuestions = [{...quizDto.questions[0], statement: `The answer to the ultimate question of life, the universe, and everything.`}];
+        quiz = await service.update(quiz.id, {...quizDto, questions: updatedQuestions} as UpdateQuizDto);
+        expect(quiz.questions).toEqual(updatedQuestions);
+      });
+    });
+    // This right here is why unit tests are so necessary:
+    //  While trying to get it to fail by replacing "questions" with "preguntas" on a patch request,
+    //  it would simply let it through, no error, except the forced fail instruction. 
+    // Running that same test through postman, the resulting quiz ended up containing both the previous 
+    //  questions set and a new preguntas one.
+    // This will be fixed with the refactor. And could be fixed before adding a database, by placing 
+    //  each entities logic and validation where it should be, implementing cascading updates by hand,
+    //  simulating stopable/"rollbackable" transactions, etc.
+    // 
+    // describe('with a quiz with no questions', () => {
+    //   it('should throw a "BadRequestException"', async () => {
+    //     try {
+    //       badDto = {name:quizDto.name, preguntas:quizDto.questions};
+    //       await service.update(quiz.id, badDto as UpdateQuizDto);
+    //       fail(`We shouldn't be here!`);
+    //     } catch (err) {
+    //       expect(err).toBeInstanceOf(BadRequestException);
+    //       expect(err.message).toEqual(`The provided Quiz “${quizDto.name}” should contain at least one question.`);
+    //       expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+    //     }
+    //   });
+    // });
+    describe('with a quiz with no answers', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          badDto = {name:quizDto.name, questions: [{statement:quizDto.questions[0].statement}]};
+          await service.update(quiz.id, badDto as UpdateQuizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`The provided Quiz's question “${quizDto.questions[0].statement}” should contain exactly 4 answers.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+    describe('with a quiz with more than one true answer', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          badDto = {
+            name:quizDto.name, 
+            questions: [{
+              statement:quizDto.questions[0].statement, 
+              answers: [{...quizDto.questions[0].answers[0],isCorrect:true}, quizDto.questions[0].answers[1], quizDto.questions[0].answers[2], quizDto.questions[0].answers[3]]
+            }]
+          };
+          await service.update(quiz.id, badDto as UpdateQuizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`The provided Quiz's question “${quizDto.questions[0].statement}” must contain 1 and only 1 true answer.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+    describe('with a quiz with no true answer', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          badDto = {
+            name:quizDto.name, 
+            questions: [{
+              statement:quizDto.questions[0].statement, 
+              answers: [quizDto.questions[0].answers[0], quizDto.questions[0].answers[1], {...quizDto.questions[0].answers[2],isCorrect:false}, quizDto.questions[0].answers[3]]
+            }]
+          };
+          await service.update(quiz.id, badDto as UpdateQuizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`The provided Quiz's question “${quizDto.questions[0].statement}” must contain 1 and only 1 true answer.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+    describe('with a valid quiz patch but the wrong id', () => {
+      it('should throw a "BadRequestException"', async () => {
+        try {
+          await service.update(quiz.id+quiz.id, quizDto);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`Quiz id “${quiz.id+quiz.id}” doesn't match any existing record. Please verify the provided update data.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+
+  });
+
+  describe(`delete`, () => {
+    describe(`when quiz with provided id exists`, () => {
+      it(`should return void`, async () => {
+        await service.remove(quiz.id);
+        try {
+          await service.findOne(quiz.id);
+          fail(`We shouldn't be here!`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(NotFoundException);
+          expect(err.message).toEqual(`No quiz with id “${quiz.id}” exists in the collection.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.NOT_FOUND);
+        }
+      });
+    });
+    describe(`when quiz with provided id doesn't exist`, () => {
+      it(`should throw a "BadRequestException"`, async () => {
+        try {
+          await service.remove(`NOT${quiz.id}`);
+        } catch (err) {
+          expect(err).toBeInstanceOf(BadRequestException);
+          expect(err.message).toEqual(`Can't delete a record which doesn't exist. Please verify and fix the id “NOT${quiz.id}”.`);
+          expect(err.response.statusCode).toEqual(HttpStatus.BAD_REQUEST);
+        }
+      });
+    });
+  });
+
 });

--- a/src/quizzes/quizzes.service.ts
+++ b/src/quizzes/quizzes.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateQuizDto } from './dto/create-quiz.dto';
+import { UpdateQuizDto } from './dto/update-quiz.dto';
+
+@Injectable()
+export class QuizzesService {
+  create(createQuizDto: CreateQuizDto) {
+    return 'This action adds a new quiz';
+  }
+
+  findAll() {
+    return `This action returns all quizzes`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} quiz`;
+  }
+
+  update(id: number, updateQuizDto: UpdateQuizDto) {
+    return `This action updates a #${id} quiz`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} quiz`;
+  }
+}

--- a/src/quizzes/quizzes.service.ts
+++ b/src/quizzes/quizzes.service.ts
@@ -1,26 +1,32 @@
+import { QuizzesRepository } from './quizzes.repository';
 import { Injectable } from '@nestjs/common';
 import { CreateQuizDto } from './dto/create-quiz.dto';
 import { UpdateQuizDto } from './dto/update-quiz.dto';
+import { Quiz } from './entities/quiz.entity';
 
 @Injectable()
 export class QuizzesService {
-  create(createQuizDto: CreateQuizDto) {
-    return 'This action adds a new quiz';
+  constructor(
+    private quizzesRepository: QuizzesRepository,
+  ) {}
+
+  async create(createQuizDto: CreateQuizDto): Promise<Quiz> {
+    return this.quizzesRepository.create(createQuizDto);
   }
 
-  findAll() {
-    return `This action returns all quizzes`;
+  async findAll(): Promise<Quiz[]> {
+    return this.quizzesRepository.findAll();
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} quiz`;
+  async findOne(id: string): Promise<Quiz> {
+    return this.quizzesRepository.findOne(id);
   }
 
-  update(id: number, updateQuizDto: UpdateQuizDto) {
-    return `This action updates a #${id} quiz`;
+  async update(id: string, updateQuizDto: UpdateQuizDto): Promise<Quiz> {
+    return this.quizzesRepository.update(id, updateQuizDto);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} quiz`;
+  async remove(id: string) {
+    return this.quizzesRepository.remove(id);
   }
 }


### PR DESCRIPTION
Chapter 1:

An API that provides an endpoint to;
- Create a new quiz
  - A quiz with a name and a collection of questions
  - Each question with precisely four possible answers
  - Each set of answers must contain a correct one (and only one).
- List all existing quizzes 
- Retrieve a single specific quiz (not specified in the assignment, but required for the next two items)
- Edit an existing quiz
- Delete an existing quiz

Plus the minimum set of tests to cover the requested features.

Note: Nest.js is packed with features that allow building REST APIs (as well as GraphQL back-ends, microservices or WebSocket apps) in an organized and efficient way. Still, it follows a "convention over configuration" approach. 
With the specific request not to add storage (database, ORM) until Chapter 2, I eventually bumped into a dilemma:
no ORM-handled entities relationships, no transactions, no cascading inserts, limited validation for each "entity" with built-in decorators, but... between overshooting to implement things that would be refactored anyways (removed, in practice) in Chapter 2, and getting as quickly as possible to Chapter 2, I chose the latter... With great shortcuts comes great technical debt, and although this felt small enough, while building the tests I realized a couple of bugs that sneaked in, related to handling the quiz update with certain questions cases. So here come the...

...Known issues:
- Can't filter out "malicious" requests data (on both create and update requests). Usually these parameters are added to the validation pipe:
  ```
  app.useGlobalPipes(new ValidationPipe({
      whitelist: true,
      transform: true,
      forbidNonWhitelisted: true,
  }));
  ```
  Without proper entity relationships, the whitelist true option in the validation pipe doesn't know what to make of the questions content and leaves it out, unable to transform it into a proper array of questions. But without that option, a manual fix is needed. I could have fixed this right away, but I'll pretend to have found out only after the QA Team came back with a verdict after running their tests in the develop branch. The refactor in Chapter 2 would take care of this, but there's a quick fix that can be applied independent of ORM, so I'll branch a bugfix out of the develop line.
- An undefined statement in a question is accepted. Again, this is a consequence of the aforementioned restraints. A case could be made for a nice Easter egg (ensuring 42 is among the list of answers, as the correct one). But I'll just skip this and let it be fixed in Chapter 2.